### PR TITLE
make the repo easier to use without use of flakes

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,8 +1,6 @@
 # nixai Home Manager Module
 # Provides user-level nixai configuration and services for Home Manager.
 # This module enables per-user nixai installation with optional editor integrations.
-{nixaiPackage ? null}:
-# Accept optional nixai package parameter
 {
   config,
   lib,
@@ -11,30 +9,6 @@
 }:
 with lib; let
   cfg = config.services.nixai;
-
-  # Use provided package or try to find nixai in pkgs, fallback to placeholder
-  defaultNixaiPackage =
-    if nixaiPackage != null
-    then nixaiPackage
-    else if pkgs ? nixai
-    then pkgs.nixai
-    else
-      pkgs.stdenv.mkDerivation {
-        pname = "nixai-placeholder";
-        version = "0.0.0";
-        src = pkgs.writeText "placeholder" "";
-        dontUnpack = true;
-        installPhase = ''
-                  mkdir -p $out/bin
-                  cat > $out/bin/nixai << 'EOF'
-          #!/bin/sh
-          echo "nixai placeholder: Please install nixai package or build from flake"
-          echo "Try: nix run github:username/nixai -- \"\$@\""
-          exit 1
-          EOF
-                  chmod +x $out/bin/nixai
-        '';
-      };
 in {
   options.services.nixai = {
     enable = mkEnableOption "nixai service";
@@ -44,9 +18,8 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = defaultNixaiPackage;
-        defaultText = literalExpression "pkgs.nixai";
-        description = "The nixai package to use. Defaults to a placeholder when nixai package is not available.";
+        default = pkgs.callPackage ../package.nix { inherit (pkgs) lib buildGoModule; };
+        description = "The nixai package to use";
       };
 
       socketPath = mkOption {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,8 +1,6 @@
 # nixai NixOS Module
 # Provides systemd services and configuration for the nixai application.
 # This module enables system-wide nixai installation with MCP server support.
-{nixaiPackage ? null}:
-# Accept optional nixai package parameter
 {
   config,
   lib,
@@ -11,33 +9,6 @@
 }:
 with lib; let
   cfg = config.services.nixai;
-
-  # Use provided package or try to find nixai in pkgs, fallback to placeholder
-  defaultNixaiPackage =
-    if nixaiPackage != null
-    then nixaiPackage
-    else if pkgs ? nixai
-    then pkgs.nixai
-    else
-      pkgs.stdenv.mkDerivation {
-        pname = "nixai-placeholder";
-        version = "0.0.0";
-        src = pkgs.writeText "placeholder" "";
-        dontUnpack = true;
-        installPhase = ''
-                    mkdir -p $out/bin
-                    cat > $out/bin/nixai << 'EOF'
-          #!/bin/sh
-          echo "nixai placeholder: Please install nixai package or build from flake"
-          echo "See: https://github.com/olafkfreund/nix-ai-help#installation"
-          exit 1
-          EOF
-                    chmod +x $out/bin/nixai
-        '';
-        meta = {
-          description = "Placeholder package for nixai (not properly installed)";
-        };
-      };
 in {
   options.services.nixai = {
     enable = mkEnableOption "nixai service";
@@ -47,7 +18,7 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = defaultNixaiPackage;
+        default = pkgs.callPackage ../package.nix { inherit (pkgs) lib buildGoModule; };
         description = "The nixai package to use";
       };
 

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  rev ? null,
+  ...
+}:
+buildGoModule {
+  pname = "nixai";
+  version = "0.1.0";
+  src = builtins.path {
+    name = "nix-ai-help";
+    path = ./.;
+  };
+  vendorHash = null;
+  modVendor = true;
+  proxyVendor = true;
+  doCheck = false;
+  subPackages = ["cmd/nixai"];
+  ldflags = let
+    version =
+      if (rev != null)
+      then rev
+      else "dirty";
+    gitCommit =
+      if (rev != null)
+      then builtins.substring 0 7 rev
+      else "unknown";
+    buildDate = "1970-01-01T00:00:00Z";
+  in [
+    "-X nix-ai-help/pkg/version.Version=${version}"
+    "-X nix-ai-help/pkg/version.GitCommit=${gitCommit}"
+    "-X nix-ai-help/pkg/version.BuildDate=${buildDate}"
+  ];
+  meta = {
+    description = "A tool for diagnosing and configuring NixOS using AI.";
+    license = lib.licenses.mit;
+    maintainers = ["olafkfreund"];
+  };
+}


### PR DESCRIPTION
this PR makes the repo easier to use without flakes:

- promoting the package definition to its own file
- making the modules batteries-included, using the above-mentioned package definition as their default
