### PR TITLE
fix: default to stderr instead of stdout for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ in {
 }
 ```
 
+### NixOS/Home Manager Integration (Flakes)
+
+Add to your `flake.nix`:
+
+```nix
+inputs = {
+  nix-ai.url = "github:olafkfreund/nix-ai-help";
+};
+```
+
+In your packages, add:
+
+```nix
+inputs.nix-ai.packages.${pkgs.system}.default
+```
+
 ## Common Usage
 
 ### Getting Help

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -26,7 +26,7 @@ type Logger struct {
 // NewLogger creates a new instance of Logger with default info level.
 func NewLogger() *Logger {
 	return &Logger{
-		Logger: log.New(os.Stdout, "", log.LstdFlags),
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
 		level:  InfoLevel,
 	}
 }


### PR DESCRIPTION
# Description

When installing nixai, the generated Fish shell completions file (nixai.fish) incorrectly contains runtime log output instead of valid Fish completion code.

Example of the first line inside ~/.config/fish/completions/nixai.fish:

```
2025/08/20 02:13:19 INFO: Loaded 0 plugins
```

This causes fish shell to throw errors like 

```
fish: Unknown command: 2025/08/20
```

## Steps to reproduce

1. Install nixai
2. Use fish shell
3. Observe the errors